### PR TITLE
bugfix/reporting_removal_on_dual_listener_close

### DIFF
--- a/src/RobotAid/listener.py
+++ b/src/RobotAid/listener.py
@@ -114,9 +114,8 @@ class RobotAid(ListenerV3):
             # This would store information for post-execution healing
 
     def close(self):
-        if self.report_info:
+        if self.report_info:    # close() method is called twice, resulting in removal of previous reports
             ReportGenerator().generate_reports(report_info=self.report_info)
-        debug=True
 
     def _start_self_healing(self, result: result.Keyword) -> None:
         """Starts the self-healing process via pydanticAI agentic system. Sets class attributes for further processing."""


### PR DESCRIPTION
The listener's close() method instantiates the reporting class and therefore deletes old reporting files (deletion is necessary due to instances where the reporting needs to access an external resource file multiple times to replace different locators, therefore building on already changed files within the reporting output).

The bug is a double listener close() invocation. After the first instance of close() the reports are generated as expected followed by another call of close() (with empty class parameters) resulting in instantiation of reporting class and therefore deletion of previous reports.

To avoid the error, the class attribute "report_info" is checked for entries. If no entries are given, the reporting class is skipped.