### PR TITLE
Misc/removed dom from log

### DIFF
--- a/SelfhealingAgents/self_healing_system/context_retrieving/dom_soap_utils.py
+++ b/SelfhealingAgents/self_healing_system/context_retrieving/dom_soap_utils.py
@@ -469,7 +469,6 @@ class SoupDomUtils:
         return "display: none" in style
 
     @staticmethod
-    @log
     def get_simplified_dom_tree(source: str) -> str | None:
         """Returns a simplified DOM tree as a string, removing non-essential elements and attributes.
 


### PR DESCRIPTION
The simplified (filtered) DOM tree was added to the log files. To increase usability of the log and to avoid having sensitive data in log file, the simplified DOM tree was removed from logging.