### PR TITLE
Feature/report_info_persistence_for_rerun_option

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ LOCATOR_AGENT_MODEL="gpt-4o-mini"
 LOCATOR_AGNET_TEMPERATURE=0.1
 LOCATOR_TYPE="css"
 REPORT_DIRECTORY="full-path-for-output-files"
+IS_RERUN_ACTIVATED=False
 ```
 
 ### 📝 Configuration Parameters
@@ -206,6 +207,7 @@ REPORT_DIRECTORY="full-path-for-output-files"
 | **LOCATOR_AGENT_TEMPERATURE**      | `0.1`           | No                       | Locator model temperature.                                                 |
 | **LOCATOR_TYPE**                   | `'css'`         | No                       | Restricts the locator suggestions of the agent to the given type           |
 | **REPORT_DIRECTORY**               | cwd             | No                       | Full path for output files.                                                |
+| **IS_RERUN_ACTIVATED**             | False           | No                       | Set to True if Rerun of failed tests is activated (affects Reporting).     |
 
 > **Note:**  
 > Locator suggestions can be generated either by assembling strings from the DOM tree (with an LLM selecting the best option), or by having the LLM generate suggestions directly itself with the context given (DOM included). Set `USE_LLM_FOR_LOCATOR_GENERATION` to `True` to enable direct LLM generation (default is True).

--- a/SelfhealingAgents/self_healing_system/reports/report_info_persistence.py
+++ b/SelfhealingAgents/self_healing_system/reports/report_info_persistence.py
@@ -1,0 +1,70 @@
+import json
+
+from pathlib import Path
+from typing import List, Iterable
+
+from SelfhealingAgents.self_healing_system.schemas.internal_state.report_data import ReportData
+
+REPORT_INFO_FILE = Path("report_info.json")
+
+
+def save_report_info(report_info: List[ReportData], path: Path | str = REPORT_INFO_FILE) -> None:
+    """Persist report_info as JSON in the given path. Used to preserve healing steps if Rerun-option of failed
+       tests is activated as the rerun would overwrite the previous run.
+    """
+    path = Path(path)
+    payload = [item.model_dump() for item in report_info]
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def load_report_info(path: Path | str = REPORT_INFO_FILE) -> List[ReportData]:
+    """Load report_info from JSON. Returns [] if file missing or invalid."""
+    path = Path(path)
+    if not path.is_file():
+        return []
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, list):
+            return []
+        return [ReportData.model_validate(obj) for obj in raw]
+    except Exception:
+        return []
+
+
+def deduplicate_report_info(report_info: Iterable[ReportData]) -> List[ReportData]:
+    """Remove duplicate ReportData entries, keeping the first occurrence.
+    Two entries are considered duplicates based on:
+      - file
+      - keyword_source
+      - test_name
+      - locator_origin
+      - keyword
+      - keyword_args
+      - lineno
+      - failed_locator
+    Differences in healed_locator or tried_locators do NOT affect duplicate status.
+    """
+    seen = set()
+    unique: List[ReportData] = []
+    for item in report_info:
+        key = (
+            item.file,
+            item.keyword_source,
+            item.test_name,
+            item.locator_origin,
+            item.keyword,
+            tuple(item.keyword_args),
+            item.lineno,
+            item.failed_locator,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(item)
+    return unique
+
+
+def sort_report_info(report_info: Iterable[ReportData]) -> List[ReportData]:
+    """Sort report entries by file and then by lineno (ascending)."""
+    return sorted(report_info, key=lambda r: (r.file, r.lineno))

--- a/SelfhealingAgents/utils/cfg.py
+++ b/SelfhealingAgents/utils/cfg.py
@@ -62,6 +62,11 @@ class Cfg(BaseSettings):
         None, env="REPORT_DIRECTORY",
         description="Path to the report directory."
     )
+    is_rerun_activated: Optional[bool] = Field(
+        False, env="IS_RERUN_ACTIVATED",
+        description="Boolean if Rerun option is activated. If True, Report folder will not be deleted to avoid overwriting the initial run."
+    )
+
     azure_api_key: Optional[str] = Field(
         None, env="AZURE_API_KEY",
         description="Azure API key"

--- a/tests/utest/test_listener.py
+++ b/tests/utest/test_listener.py
@@ -2,6 +2,7 @@ import sys
 import types
 import pytest
 import importlib
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -47,22 +48,59 @@ def _ensure_robot_stubs() -> None:
 
 
 @pytest.fixture
-def listener() -> Any:
+def listener(tmp_path: Path) -> Any:
     _ensure_robot_stubs()
 
-    sys.modules.pop("SelfhealingAgents.listener", None)
-    mod = importlib.import_module("SelfhealingAgents.listener")
+    orig_cwd = Path.cwd()
+    try:
+        import os
+        os.chdir(tmp_path)
 
-    with patch.object(mod, "SelfHealingEngine") as MockEngine, \
-         patch.object(mod, "ReportGenerator") as MockReportGen, \
-         patch.object(mod, "ListenerState") as MockState, \
-         patch.object(mod, "Cfg") as MockCfg:
-        mock_engine = MockEngine.return_value
-        mock_report_gen = MockReportGen.return_value
-        mock_state = MockState.return_value
-        mock_state.cfg.enable_self_healing = True
-        mock_state.report_info = {"dummy": "info"}
-        yield mod.SelfhealingAgents()
+        sys.modules.pop("SelfhealingAgents.listener", None)
+        mod = importlib.import_module("SelfhealingAgents.listener")
+
+        with patch.object(mod, "SelfHealingEngine") as MockEngine, \
+                patch.object(mod, "ReportGenerator") as MockReportGen, \
+                patch.object(mod, "ListenerState") as MockState, \
+                patch.object(mod, "Cfg") as MockCfg, \
+                patch.object(mod, "save_report_info") as mock_save_report_info, \
+                patch.object(mod, "load_report_info") as mock_load_report_info, \
+                patch.object(mod, "deduplicate_report_info") as mock_dedup, \
+                patch.object(mod, "sort_report_info") as mock_sort:
+            mock_cfg = MockCfg.return_value
+            mock_cfg.enable_self_healing = True
+            mock_cfg.is_rerun_activated = False
+            mock_cfg.report_directory = tmp_path
+
+            mock_state = MockState.return_value
+            mock_state.cfg = mock_cfg
+            mock_state.report_info = None
+
+            mock_engine = MockEngine.return_value
+            mock_report_gen = MockReportGen.return_value
+
+            mod._test_mocks = {
+                "engine": mock_engine,
+                "report_gen": mock_report_gen,
+                "state": mock_state,
+                "cfg": mock_cfg,
+                "save_report_info": mock_save_report_info,
+                "load_report_info": mock_load_report_info,
+                "dedup": mock_dedup,
+                "sort": mock_sort,
+            }
+
+            inst = mod.SelfhealingAgents()
+            yield inst
+
+    finally:
+        import os
+        os.chdir(orig_cwd)
+
+
+def _get_internals(listener: Any) -> dict[str, Any]:
+    mod = importlib.import_module("SelfhealingAgents.listener")
+    return mod._test_mocks  # type: ignore[attr-defined]
 
 
 def test_initialization_logs_and_sets_state(listener: Any) -> None:
@@ -73,53 +111,168 @@ def test_initialization_logs_and_sets_state(listener: Any) -> None:
 
 
 def test_start_test_delegates_to_engine(listener: Any) -> None:
+    internals = _get_internals(listener)
+    engine = internals["engine"]
+
     dummy_data = MagicMock()
     dummy_result = MagicMock()
-    engine = listener._self_healing_engine
     listener.start_test(dummy_data, dummy_result)
     engine.start_test.assert_called_once_with(dummy_data, dummy_result)
 
 
 def test_end_keyword_delegates_to_engine(listener: Any) -> None:
+    internals = _get_internals(listener)
+    engine = internals["engine"]
+
     dummy_data = MagicMock()
     dummy_result = MagicMock()
-    engine = listener._self_healing_engine
     listener.end_keyword(dummy_data, dummy_result)
     engine.end_keyword.assert_called_once_with(dummy_data, dummy_result)
 
 
 def test_end_test_delegates_to_engine(listener: Any) -> None:
+    internals = _get_internals(listener)
+    engine = internals["engine"]
+
     dummy_data = MagicMock()
     dummy_result = MagicMock()
-    engine = listener._self_healing_engine
     listener.end_test(dummy_data, dummy_result)
     engine.end_test.assert_called_once_with(dummy_data, dummy_result)
 
 
-def test_close_generates_report_once(listener: Any) -> None:
-    report_gen = listener._report_generator
-    state = listener._state
-    state.report_info = {"dummy": "info"}
-    listener.close()
-    report_gen.generate_reports.assert_called_once_with(state.report_info)
-    listener.close()
-    report_gen.generate_reports.assert_called_once()
+def test_close_no_rerun_no_report_info(listener: Any) -> None:
+    internals = _get_internals(listener)
+    report_gen = internals["report_gen"]
+    state = internals["state"]
+    cfg = internals["cfg"]
 
-
-def test_close_no_report_if_no_info(listener: Any) -> None:
-    report_gen = listener._report_generator
-    state = listener._state
+    cfg.is_rerun_activated = False
     state.report_info = None
+
     listener.close()
     report_gen.generate_reports.assert_not_called()
 
 
-def test_close_handles_exceptions_gracefully(listener: Any) -> None:
-    report_gen = listener._report_generator
-    state = listener._state
-    state.report_info = {"dummy": "info"}
+def test_close_no_rerun_report_generation_exception_is_swallowed(listener: Any) -> None:
+    internals = _get_internals(listener)
+    report_gen = internals["report_gen"]
+    state = internals["state"]
+    cfg = internals["cfg"]
+
+    cfg.is_rerun_activated = False
+    state.report_info = [{"dummy": "info"}]
     report_gen.generate_reports.side_effect = Exception("fail")
+
     try:
         listener.close()
     except Exception:
-        pytest.fail("Exception should not propagate from close()")
+        pytest.fail("Exception should not propagate from close() when no rerun is activated")
+
+    report_gen.generate_reports.assert_called_once_with(state.report_info)
+
+
+def test_close_rerun_initial_run_persists_and_generates(listener: Any, tmp_path: Path) -> None:
+    internals = _get_internals(listener)
+    report_gen = internals["report_gen"]
+    state = internals["state"]
+    cfg = internals["cfg"]
+    save_report_info = internals["save_report_info"]
+
+    cfg.is_rerun_activated = True
+    state.report_info = [{"dummy": "info"}]
+
+    from SelfhealingAgents.self_healing_system.reports.report_info_persistence import REPORT_INFO_FILE
+    json_path = Path.cwd() / REPORT_INFO_FILE.name
+    if json_path.exists():
+        json_path.unlink()
+
+    listener.close()
+
+    save_report_info.assert_called_once_with(state.report_info, json_path)
+    report_gen.generate_reports.assert_called_once_with(state.report_info)
+
+
+def test_close_rerun_initial_run_no_report_info(listener: Any) -> None:
+    internals = _get_internals(listener)
+    report_gen = internals["report_gen"]
+    state = internals["state"]
+    cfg = internals["cfg"]
+    save_report_info = internals["save_report_info"]
+
+    cfg.is_rerun_activated = True
+    state.report_info = None
+
+    from SelfhealingAgents.self_healing_system.reports.report_info_persistence import REPORT_INFO_FILE
+    json_path = Path.cwd() / REPORT_INFO_FILE.name
+    if json_path.exists():
+        json_path.unlink()
+
+    listener.close()
+
+    save_report_info.assert_not_called()
+    report_gen.generate_reports.assert_not_called()
+
+
+def test_close_rerun_second_run_merges_and_generates_and_cleans_up(listener: Any) -> None:
+    internals = _get_internals(listener)
+    report_gen = internals["report_gen"]
+    state = internals["state"]
+    cfg = internals["cfg"]
+    save_report_info = internals["save_report_info"]
+    load_report_info = internals["load_report_info"]
+    dedup = internals["dedup"]
+    sort = internals["sort"]
+
+    cfg.is_rerun_activated = True
+    state.report_info = [{"run": 2}]
+
+    from SelfhealingAgents.self_healing_system.reports.report_info_persistence import REPORT_INFO_FILE
+    json_path = Path.cwd() / REPORT_INFO_FILE.name
+
+    json_path.write_text("[]")
+    previous = [{"run": 1}]
+    load_report_info.return_value = previous
+
+    combined = previous + state.report_info
+    deduped = combined
+    ordered = list(reversed(deduped))
+    dedup.return_value = deduped
+    sort.return_value = ordered
+
+    listener.close()
+
+    load_report_info.assert_called_once_with(json_path)
+    dedup.assert_called_once_with(combined)
+    sort.assert_called_once_with(deduped)
+    save_report_info.assert_called_once_with(ordered, json_path)
+    report_gen.generate_reports.assert_called_once_with(ordered)
+
+    assert not json_path.exists()
+
+
+def test_close_rerun_persistence_errors_are_swallowed(listener: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    internals = _get_internals(listener)
+    cfg = internals["cfg"]
+    state = internals["state"]
+
+    cfg.is_rerun_activated = True
+    state.report_info = [{"dummy": "info"}]
+
+    from SelfhealingAgents.self_healing_system.reports.report_info_persistence import REPORT_INFO_FILE
+    json_path = Path.cwd() / REPORT_INFO_FILE.name
+    if json_path.exists():
+        json_path.unlink()
+
+    original_exists = Path.exists
+
+    def boom_exists(self: Path) -> bool:  # type: ignore[override]
+        if self.name == REPORT_INFO_FILE.name:
+            raise RuntimeError("exists failed")
+        return original_exists(self)
+
+    monkeypatch.setattr(Path, "exists", boom_exists, raising=True)
+
+    try:
+        listener.close()
+    except Exception:
+        pytest.fail("Exception from persistence logic should be swallowed in close() with rerun")


### PR DESCRIPTION
In some instances the user uses the Rerun library (`robotframework-retryfailed`) to rerun failed tests after an initial run.
For the selfhealing library this has the effect of another listener instance that is created, despite having "global" scope.

When a listener instance is created, the report info will be lost and the generated report files will be deleted.
To circumvent this problem, a temporary json is dumped into the cwd and loaded on rerun to append to the new report info. Duplicates and order problems are solved aswell.

In short: The temporary json dump and load allows the report_info to be persistent so that reports can be generated for both runs, the initial and rerun.